### PR TITLE
Added additional e2e test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-e2e: build ## Run end-to-end tests
 
 test-e2e-single: build ## Run a single E2E test (usage: make test-e2e-single TEST=TestCrashLoopBackoffDiagnosis)
 	@echo "Running single E2E test: $(TEST)"
-	@go test -v ./test/e2e/... -run $(TEST)
+	@go test -v ./test/e2e/... -run $(TEST) -preserve-on-failure
 
 test-coverage: ## Run tests with coverage
 	@echo "Running tests with coverage..."

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -42,12 +42,13 @@ go test -v ./test/e2e/... -run TestCrashLoopBackoffDiagnosis
 1. **CrashLoopBackOff**: Tests k8x's ability to diagnose a pod in CrashLoopBackOff state due to an exit code 1
 2. **ImagePullBackOff**: Tests diagnosing a pod that can't pull its container image
 3. **Missing ConfigMap**: Tests diagnosing a pod that depends on a non-existent ConfigMap
+4. **Kubectl Exit Code Validation**: Tests the framework's ability to handle kubectl command failures and validates that k8x can analyze various resource scenarios
 
 ## Adding New Test Cases
 
 To add a new test scenario:
 
-1. Create a new scenario function in `framework/scenarios/pod_failures.go`
+1. Create a new scenario function in `framework/scenarios/pod_failures.go` or `framework/scenarios/opa_gatekeeper.go`
 2. Add a new test function in `run_e2e_test.go`
 3. Ensure the test creates a unique kind cluster name to avoid conflicts with existing tests
 

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -64,9 +64,18 @@ func NewClusterFixture(t *testing.T, name string) (*ClusterFixture, error) {
 	}, nil
 }
 
-// Cleanup deletes the kind cluster and temporary files
-func (c *ClusterFixture) Cleanup() {
+// CleanupConditional deletes the kind cluster based on failure state and flags
+func (c *ClusterFixture) Cleanup(isFailure bool) {
 	c.t.Helper()
+
+	// Check if we should preserve on failure
+	if isFailure && ShouldPreserveOnFailure() {
+		c.t.Logf("Preserving kind cluster %q after test failure due to --preserve-on-failure flag", c.Name)
+		c.t.Logf("To manually clean up later, run: kind delete cluster --name %s", c.Name)
+		c.t.Logf("Kubeconfig available at: %s", c.KubeConfigPath)
+		return
+	}
+
 	c.t.Logf("Cleaning up kind cluster %q...", c.Name)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -81,6 +90,8 @@ func (c *ClusterFixture) Cleanup() {
 
 	if err := cmd.Run(); err != nil {
 		c.t.Logf("Warning: failed to delete kind cluster: %v", err)
+	} else {
+		c.t.Logf("Successfully deleted kind cluster %q", c.Name)
 	}
 
 	// Remove temp directory containing kubeconfig
@@ -88,6 +99,8 @@ func (c *ClusterFixture) Cleanup() {
 		tempDir := filepath.Dir(c.KubeConfigPath)
 		if err := os.RemoveAll(tempDir); err != nil {
 			c.t.Logf("Warning: failed to remove temp directory: %v", err)
+		} else {
+			c.t.Logf("Successfully removed temp directory: %s", tempDir)
 		}
 	}
 }
@@ -135,107 +148,37 @@ func (c *ClusterFixture) ApplyManifest(yamlContent string) error {
 	return nil
 }
 
-// WaitForPod waits for a pod to be ready or in a specific state
-func (c *ClusterFixture) WaitForPod(namespace, podNamePrefix, condition string, timeout time.Duration) error {
+// ExecuteCommands executes a list of shell commands sequentially
+func (c *ClusterFixture) ExecuteCommands(commands [][]string) error {
 	c.t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	for i, cmdArgs := range commands {
+		c.t.Logf("Executing command %d/%d: %s", i+1, len(commands), strings.Join(cmdArgs, " "))
 
-	c.t.Logf("Waiting for pod %s in namespace %s to be %s...", podNamePrefix, namespace, condition)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 
-	args := []string{
-		"--kubeconfig", c.KubeConfigPath,
-		"-n", namespace,
-		"wait", "pod",
-		"--for", "condition=" + condition,
-		"--selector", fmt.Sprintf("app=%s", podNamePrefix),
-		"--timeout", timeout.String(),
-	}
+		cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
 
-	cmd := exec.CommandContext(ctx, "kubectl", args...)
+		// Set KUBECONFIG environment for all commands (kubectl, helm, etc.)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", c.KubeConfigPath))
 
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pod never reached %s state: %w, stderr: %s", condition, err, stderr.String())
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("command %d failed (%s): %w\nstdout: %s\nstderr: %s",
+				i+1, strings.Join(cmdArgs, " "), err, stdout.String(), stderr.String())
+		}
+
+		c.t.Logf("Command %d completed successfully", i+1)
+		if stdout.Len() > 0 {
+			c.t.Logf("Command output: %s", stdout.String())
+		}
 	}
 
 	return nil
-}
-
-// WaitForPodStatus waits for a pod to reach a specific status condition like CrashLoopBackOff
-func (c *ClusterFixture) WaitForPodStatus(namespace, podNamePrefix, status string, timeout time.Duration) error {
-	c.t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	c.t.Logf("Waiting for pod %s in namespace %s to reach status %s...", podNamePrefix, namespace, status)
-
-	// Poll the pod status until it matches what we expect
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for pod %s to reach status %s", podNamePrefix, status)
-		case <-ticker.C:
-			// Get pod status
-			cmd := exec.CommandContext(
-				context.Background(),
-				"kubectl",
-				"--kubeconfig", c.KubeConfigPath,
-				"-n", namespace,
-				"get", "pods",
-				"--selector", fmt.Sprintf("app=%s", podNamePrefix),
-				"-o", "jsonpath={.items[0].status.containerStatuses[0].state}",
-			)
-
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			if err := cmd.Run(); err != nil {
-				c.t.Logf("Error getting pod status: %v, stderr: %s", err, stderr.String())
-				continue
-			}
-
-			statusOutput := strings.TrimSpace(stdout.String())
-			c.t.Logf("Pod status: %s", statusOutput)
-
-			// Check if the status contains what we're looking for
-			if strings.Contains(strings.ToLower(statusOutput), strings.ToLower(status)) {
-				c.t.Logf("Pod %s reached status %s", podNamePrefix, status)
-				return nil
-			}
-
-			// Also check phase for some conditions
-			phaseCmd := exec.CommandContext(
-				context.Background(),
-				"kubectl",
-				"--kubeconfig", c.KubeConfigPath,
-				"-n", namespace,
-				"get", "pods",
-				"--selector", fmt.Sprintf("app=%s", podNamePrefix),
-				"-o", "jsonpath={.items[0].status.phase}",
-			)
-
-			var phaseStdout, phaseStderr bytes.Buffer
-			phaseCmd.Stdout = &phaseStdout
-			phaseCmd.Stderr = &phaseStderr
-
-			if err := phaseCmd.Run(); err == nil {
-				phaseOutput := strings.TrimSpace(phaseStdout.String())
-				if strings.Contains(strings.ToLower(phaseOutput), strings.ToLower(status)) {
-					c.t.Logf("Pod %s reached phase %s", podNamePrefix, status)
-					return nil
-				}
-			}
-		}
-	}
 }
 
 // RunK8x executes the k8x command against the cluster
@@ -303,7 +246,7 @@ settings:
 `, c.Name)
 
 	if err := os.WriteFile(filepath.Join(k8xConfigDir, "config.yaml"), []byte(configContent), 0644); err != nil {
-		return "", fmt.Errorf("failed to write k8x config file: %w", err)
+		return "", fmt.Errorf("failed to write to k8x config file: %w", err)
 	}
 
 	// Create credentials file
@@ -348,6 +291,305 @@ openai:
 	}
 
 	return output, nil
+}
+
+// ResourceConditionChecker defines how to check if a resource meets a condition
+type ResourceConditionChecker interface {
+	Check(c *ClusterFixture) (bool, error)
+	Description() string
+}
+
+// KubectlWaitConditionChecker uses kubectl wait command for standard conditions
+type KubectlWaitConditionChecker struct {
+	ResourceType string
+	Name         string
+	Namespace    string
+	Condition    string
+	Selector     string
+	description  string
+}
+
+func (k *KubectlWaitConditionChecker) Check(c *ClusterFixture) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	args := []string{
+		"--kubeconfig", c.KubeConfigPath,
+		"wait", k.ResourceType,
+		"--for", k.Condition,
+		"--timeout", "5s",
+	}
+
+	if k.Namespace != "" {
+		args = append(args, "-n", k.Namespace)
+	}
+
+	if k.Selector != "" {
+		args = append(args, "--selector", k.Selector)
+	} else if k.Name != "" {
+		args = append(args, k.Name)
+	}
+
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Log the error for debugging but don't fail - this is expected during waiting
+		if stderr.Len() > 0 {
+			c.t.Logf("kubectl wait failed (expected during polling): %v, stderr: %s", err, stderr.String())
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (k *KubectlWaitConditionChecker) Description() string {
+	if k.description != "" {
+		return k.description
+	}
+	return fmt.Sprintf("%s to have condition %s", k.ResourceType, k.Condition)
+}
+
+// WaitForResourceCondition is the unified waiting function
+func (c *ClusterFixture) WaitForResourceCondition(checker ResourceConditionChecker, timeout time.Duration) error {
+	c.t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	c.t.Logf("Waiting for %s...", checker.Description())
+
+	// Check immediately first
+	if satisfied, err := checker.Check(c); err != nil {
+		return fmt.Errorf("initial check failed for %s: %w", checker.Description(), err)
+	} else if satisfied {
+		c.t.Logf("Condition already met: %s", checker.Description())
+		return nil
+	}
+
+	ticker := time.NewTicker(5 * time.Second) // Reduced from 10s for faster polling
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for %s", checker.Description())
+		case <-ticker.C:
+			if satisfied, err := checker.Check(c); err != nil {
+				c.t.Logf("Error checking condition: %v", err)
+				continue
+			} else if satisfied {
+				c.t.Logf("Condition met: %s", checker.Description())
+				return nil
+			}
+		}
+	}
+}
+
+// PodStatusChecker checks for specific container states in pods
+type PodStatusChecker struct {
+	Namespace      string
+	PodNamePrefix  string
+	ExpectedStatus string
+	description    string
+}
+
+func (p *PodStatusChecker) Check(c *ClusterFixture) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// For CrashLoopBackOff, we need to check both the waiting reason and restart count
+	if p.ExpectedStatus == "CrashLoopBackOff" {
+		// Get both waiting reason and restart count separately for more robust checking
+		waitingCmd := exec.CommandContext(
+			ctx,
+			"kubectl",
+			"--kubeconfig", c.KubeConfigPath,
+			"-n", p.Namespace,
+			"get", "pods",
+			"--selector", fmt.Sprintf("app=%s", p.PodNamePrefix),
+			"-o", "jsonpath={.items[*].status.containerStatuses[*].state.waiting.reason}",
+		)
+
+		var waitingStdout, waitingStderr bytes.Buffer
+		waitingCmd.Stdout = &waitingStdout
+		waitingCmd.Stderr = &waitingStderr
+
+		restartCmd := exec.CommandContext(
+			ctx,
+			"kubectl",
+			"--kubeconfig", c.KubeConfigPath,
+			"-n", p.Namespace,
+			"get", "pods",
+			"--selector", fmt.Sprintf("app=%s", p.PodNamePrefix),
+			"-o", "jsonpath={.items[*].status.containerStatuses[*].restartCount}",
+		)
+
+		var restartStdout, restartStderr bytes.Buffer
+		restartCmd.Stdout = &restartStdout
+		restartCmd.Stderr = &restartStderr
+
+		waitingErr := waitingCmd.Run()
+		restartErr := restartCmd.Run()
+
+		waitingReason := strings.TrimSpace(waitingStdout.String())
+		restartCountStr := strings.TrimSpace(restartStdout.String())
+
+		c.t.Logf("Pod status check: waiting reason='%s', restart count='%s'", waitingReason, restartCountStr)
+
+		// Check if the waiting reason is CrashLoopBackOff
+		if waitingErr == nil && waitingReason == "CrashLoopBackOff" {
+			c.t.Logf("Found CrashLoopBackOff state with restart count: %s", restartCountStr)
+			return true, nil
+		}
+
+		// For early CrashLoopBackOff detection, if restart count > 0, check for Error state
+		if restartErr == nil && restartCountStr != "" && restartCountStr != "0" {
+			// Also check if the last state was terminated with Error
+			terminatedCmd := exec.CommandContext(
+				ctx,
+				"kubectl",
+				"--kubeconfig", c.KubeConfigPath,
+				"-n", p.Namespace,
+				"get", "pods",
+				"--selector", fmt.Sprintf("app=%s", p.PodNamePrefix),
+				"-o", "jsonpath={.items[*].status.containerStatuses[*].lastState.terminated.reason}",
+			)
+
+			var terminatedStdout bytes.Buffer
+			terminatedCmd.Stdout = &terminatedStdout
+
+			if terminatedCmd.Run() == nil {
+				terminatedReason := strings.TrimSpace(terminatedStdout.String())
+				if terminatedReason == "Error" {
+					c.t.Logf("Found Error state with restart count %s, treating as CrashLoopBackOff", restartCountStr)
+					return true, nil
+				}
+			}
+		}
+
+		return false, nil
+	}
+
+	// For other statuses, check waiting reason first
+	cmd := exec.CommandContext(
+		ctx,
+		"kubectl",
+		"--kubeconfig", c.KubeConfigPath,
+		"-n", p.Namespace,
+		"get", "pods",
+		"--selector", fmt.Sprintf("app=%s", p.PodNamePrefix),
+		"-o", "jsonpath={.items[*].status.containerStatuses[*].state.waiting.reason}",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Also check terminated state for some container states
+		terminatedCmd := exec.CommandContext(
+			ctx,
+			"kubectl",
+			"--kubeconfig", c.KubeConfigPath,
+			"-n", p.Namespace,
+			"get", "pods",
+			"--selector", fmt.Sprintf("app=%s", p.PodNamePrefix),
+			"-o", "jsonpath={.items[*].status.containerStatuses[*].lastState.terminated.reason}",
+		)
+
+		var terminatedStdout bytes.Buffer
+		terminatedCmd.Stdout = &terminatedStdout
+
+		if terminatedErr := terminatedCmd.Run(); terminatedErr != nil {
+			c.t.Logf("Failed to get container state: waiting: %v, terminated: %v", err, terminatedErr)
+			return false, nil
+		}
+
+		containerState := strings.TrimSpace(terminatedStdout.String())
+		return containerState == p.ExpectedStatus, nil
+	}
+
+	containerState := strings.TrimSpace(stdout.String())
+	return containerState == p.ExpectedStatus, nil
+}
+
+func (p *PodStatusChecker) Description() string {
+	if p.description != "" {
+		return p.description
+	}
+	return fmt.Sprintf("pod %s to have container status %s", p.PodNamePrefix, p.ExpectedStatus)
+}
+
+// WaitForPodStatus waits for a pod to reach a specific status condition
+func (c *ClusterFixture) WaitForPodStatus(namespace, podNamePrefix, status string, timeout time.Duration) error {
+	// Handle container states vs pod conditions differently
+	if status == "CrashLoopBackOff" || status == "ImagePullBackOff" || status == "ErrImagePull" {
+		// These are container states, use PodStatusChecker
+		checker := &PodStatusChecker{
+			Namespace:      namespace,
+			PodNamePrefix:  podNamePrefix,
+			ExpectedStatus: status,
+			description:    fmt.Sprintf("pod %s to have container status %s", podNamePrefix, status),
+		}
+		return c.WaitForResourceCondition(checker, timeout)
+	} else {
+		// These are pod conditions, use KubectlWaitConditionChecker
+		checker := &KubectlWaitConditionChecker{
+			ResourceType: "pod",
+			Namespace:    namespace,
+			Condition:    fmt.Sprintf("condition=%s", status), // This should be "Ready", "PodScheduled", etc.
+			Selector:     fmt.Sprintf("app=%s", podNamePrefix),
+			description:  fmt.Sprintf("pod %s to have condition %s", podNamePrefix, status),
+		}
+		return c.WaitForResourceCondition(checker, timeout)
+	}
+}
+
+// WaitForDeployment waits for a deployment to be ready
+func (c *ClusterFixture) WaitForDeployment(namespace, deploymentName string, timeout time.Duration) error {
+	checker := &KubectlWaitConditionChecker{
+		ResourceType: "deployment",
+		Name:         deploymentName,
+		Namespace:    namespace,
+		Condition:    "condition=Available",
+		description:  fmt.Sprintf("deployment %s to be ready", deploymentName),
+	}
+	return c.WaitForResourceCondition(checker, timeout)
+}
+
+// WaitForConstraintTemplate waits for a ConstraintTemplate to be established
+func (c *ClusterFixture) WaitForConstraintTemplate(name string, timeout time.Duration) error {
+	checker := &KubectlWaitConditionChecker{
+		ResourceType: "constrainttemplate",
+		Name:         name,
+		Condition:    "condition=Ready",
+		description:  fmt.Sprintf("ConstraintTemplate %s to be established", name),
+	}
+	return c.WaitForResourceCondition(checker, timeout)
+}
+
+// WaitForConstraint waits for a constraint to be ready
+func (c *ClusterFixture) WaitForConstraint(kind, name string, timeout time.Duration) error {
+	checker := &KubectlWaitConditionChecker{
+		ResourceType: strings.ToLower(kind),
+		Name:         name,
+		Condition:    "condition=Ready",
+		description:  fmt.Sprintf("%s constraint %s to be ready", kind, name),
+	}
+	return c.WaitForResourceCondition(checker, timeout)
+}
+
+// WaitForCRD waits for a CRD to be established
+func (c *ClusterFixture) WaitForCRD(crdName string, timeout time.Duration) error {
+	checker := &KubectlWaitConditionChecker{
+		ResourceType: "crd",
+		Name:         crdName,
+		Condition:    "condition=Established",
+		description:  fmt.Sprintf("CRD %s to be established", crdName),
+	}
+	return c.WaitForResourceCondition(checker, timeout)
 }
 
 // GetPodLogs retrieves logs from a pod

--- a/test/e2e/framework/flags.go
+++ b/test/e2e/framework/flags.go
@@ -1,0 +1,15 @@
+package framework
+
+import (
+	"flag"
+)
+
+var (
+	// preserveOnFailure controls whether test clusters should be preserved when tests fail
+	preserveOnFailure = flag.Bool("preserve-on-failure", false, "Preserve test clusters and resources when tests fail for debugging purposes")
+)
+
+// ShouldPreserveOnFailure returns true if test clusters should be preserved when tests fail
+func ShouldPreserveOnFailure() bool {
+	return *preserveOnFailure
+}

--- a/test/e2e/framework/scenarios/opa_gatekeeper.go
+++ b/test/e2e/framework/scenarios/opa_gatekeeper.go
@@ -1,0 +1,118 @@
+package scenarios
+
+// GatekeeperInstallationCommands returns the commands to install Gatekeeper using the official Helm chart
+func GatekeeperInstallationCommands(releaseName string) [][]string {
+	return [][]string{
+		// Add the official Gatekeeper Helm repository
+		{"helm", "repo", "add", "gatekeeper", "https://open-policy-agent.github.io/gatekeeper/charts"},
+		// Update Helm repositories
+		{"helm", "repo", "update"},
+		// Install Gatekeeper using Helm
+		{"helm", "install", releaseName, "gatekeeper/gatekeeper", "--namespace", "gatekeeper-system", "--create-namespace", "--wait", "--timeout=300s"},
+	}
+}
+
+// GatekeeperUninstallCommands returns the commands to uninstall Gatekeeper
+func GatekeeperUninstallCommands(releaseName string) [][]string {
+	return [][]string{
+		// Uninstall Gatekeeper Helm release
+		{"helm", "uninstall", releaseName, "--namespace", "gatekeeper-system"},
+		// Delete the namespace
+		{"kubectl", "delete", "namespace", "gatekeeper-system", "--ignore-not-found"},
+		// Clean up CRDs (as recommended in Gatekeeper docs)
+		{"kubectl", "delete", "crd", "-l", "gatekeeper.sh/system=yes", "--ignore-not-found"},
+	}
+}
+
+// HostPortConstraintTemplateScenario returns a ConstraintTemplate that forbids hostPort
+func HostPortConstraintTemplateScenario() string {
+	return `apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8xhostportforbidden
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8xHostPortForbidden
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8xhostportforbidden
+
+        violation[{"msg": msg}] {
+          input.review.object.kind == "Deployment"
+          container := input.review.object.spec.template.spec.containers[_]
+          port := container.ports[_]
+          port.hostPort
+          msg := sprintf("hostPort %v is forbidden by policy", [port.hostPort])
+        }
+
+        violation[{"msg": msg}] {
+          input.review.object.kind == "Pod"
+          container := input.review.object.spec.containers[_]
+          port := container.ports[_]
+          port.hostPort
+          msg := sprintf("hostPort %v is forbidden by policy", [port.hostPort])
+        }
+`
+}
+
+// HostPortConstraintScenario returns a constraint that uses the HostPortForbidden template
+func HostPortConstraintScenario() string {
+	return `apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8xHostPortForbidden
+metadata:
+  name: hostport-not-allowed
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    message: "hostPort is not allowed in this cluster for security reasons"
+`
+}
+
+// ForbiddenDeploymentScenario returns a deployment that violates the hostPort constraint
+func ForbiddenDeploymentScenario() string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forbidden-hostport-app
+  namespace: default
+  labels:
+    app: forbidden-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forbidden-app
+  template:
+    metadata:
+      labels:
+        app: forbidden-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.20
+        ports:
+        - containerPort: 80
+          hostPort: 8080  # This should be forbidden by Gatekeeper
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+`
+}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,0 +1,73 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// CheckRequirements verifies that all required tools are installed
+func CheckRequirements() error {
+	requiredCommands := []string{"kind", "kubectl", "docker"}
+
+	for _, cmd := range requiredCommands {
+		if _, err := exec.LookPath(cmd); err != nil {
+			return fmt.Errorf("required command not found: %s - please install it before running E2E tests", cmd)
+		}
+	}
+
+	// Check that the k8x binary exists
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Walk up to find the repository root
+	repoRoot := wd
+	for {
+		if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(repoRoot)
+		if parent == repoRoot {
+			return fmt.Errorf("could not find repository root")
+		}
+		repoRoot = parent
+	}
+
+	k8xPath := filepath.Join(repoRoot, "build", "k8x")
+	if _, err := os.Stat(k8xPath); os.IsNotExist(err) {
+		return fmt.Errorf("k8x binary not found at %s, please run 'make build' first", k8xPath)
+	}
+
+	return nil
+}
+
+// CheckEnvironment checks the environment and prints warnings
+func CheckEnvironment() error {
+	// Check if Docker is running
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		fmt.Println("Docker does not seem to be running. Please start Docker before running E2E tests.")
+		return fmt.Errorf("Warning: Docker does not seem to be running. E2E tests will fail.")
+	}
+
+	// Check for API key
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Println("To run complete tests, set the environment variable:")
+		fmt.Println("    export OPENAI_API_KEY=your-api-key")
+		return fmt.Errorf("Warning: OPENAI_API_KEY is not set. E2E tests will use a dummy API key and may fail.")
+	}
+
+	// Check if in CI
+	if IsRunningInCI() {
+		fmt.Println("Running in CI environment.")
+		if IsExternalPR() && !HasAPIKeys() {
+			fmt.Println("External PR detected without API keys available.")
+			fmt.Println("Tests will be compiled but skipped at runtime.")
+			return fmt.Errorf("Warning: Running in external PR without API keys. E2E tests will be skipped.")
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,89 +22,44 @@ func TestMain(m *testing.M) {
 	}
 
 	// Ensure required commands are available
-	if err := checkRequirements(); err != nil {
+	if err := framework.CheckRequirements(); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Check environment and print any warnings
-	checkEnvironment()
+	if err := framework.CheckEnvironment(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(2)
+	}
 
 	// Run tests
 	exitCode := m.Run()
 
-	// Always clean up any leftover clusters
-	cleanupClusters()
+	// Clean up any leftover clusters unless cleanup is disabled
+	cleanupClusters(exitCode != 0)
 
 	os.Exit(exitCode)
 }
 
-// checkRequirements verifies that all required tools are installed
-func checkRequirements() error {
-	requiredCommands := []string{"kind", "kubectl", "docker"}
-
-	for _, cmd := range requiredCommands {
-		if _, err := exec.LookPath(cmd); err != nil {
-			return fmt.Errorf("required command not found: %s - please install it before running E2E tests", cmd)
-		}
-	}
-
-	// Check that the k8x binary exists
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	// Walk up to find the repository root
-	repoRoot := wd
-	for {
-		if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err == nil {
-			break
-		}
-		parent := filepath.Dir(repoRoot)
-		if parent == repoRoot {
-			return fmt.Errorf("could not find repository root")
-		}
-		repoRoot = parent
-	}
-
-	k8xPath := filepath.Join(repoRoot, "build", "k8x")
-	if _, err := os.Stat(k8xPath); os.IsNotExist(err) {
-		return fmt.Errorf("k8x binary not found at %s, please run 'make build' first", k8xPath)
-	}
-
-	return nil
-}
-
-// checkEnvironment checks the environment and prints warnings
-func checkEnvironment() {
-	// Check if Docker is running
-	if err := exec.Command("docker", "info").Run(); err != nil {
-		fmt.Println("Warning: Docker does not seem to be running. E2E tests will fail.")
-	}
-
-	// Check for API key
-	if os.Getenv("OPENAI_API_KEY") == "" {
-		fmt.Println("Warning: OPENAI_API_KEY is not set. E2E tests will use a dummy API key and may fail.")
-		fmt.Println("To run complete tests, set the environment variable:")
-		fmt.Println("    export OPENAI_API_KEY=your-api-key")
-	}
-
-	// Check if in CI
-	if framework.IsRunningInCI() {
-		fmt.Println("Running in CI environment.")
-		if framework.IsExternalPR() && !framework.HasAPIKeys() {
-			fmt.Println("External PR detected without API keys available.")
-			fmt.Println("Tests will be compiled but skipped at runtime.")
-		}
-	}
-}
-
 // cleanupClusters attempts to clean up any leftover kind clusters from failed tests
-func cleanupClusters() {
+func cleanupClusters(testFailed bool) {
+
+	// If preserve-on-failure is set, warn about potential leftover clusters
+	if framework.ShouldPreserveOnFailure() && testFailed {
+		fmt.Println("Warning: preserve-on-failure is enabled. Clusters will be preserved.")
+		fmt.Println("To see all clusters: kind get clusters")
+		fmt.Println("To delete a specific cluster: kind delete cluster --name <cluster-name>")
+		return // Skip cleanup if preserve-on-failure is set
+	}
+
 	prefix := "k8x-test-"
+
+	fmt.Printf("Looking for clusters with prefix: %s\n", prefix)
+
 	out, err := exec.Command("kind", "get", "clusters").Output()
 	if err != nil {
+		fmt.Printf("Failed to get clusters: %v\n", err)
 		return // Ignore errors
 	}
 
@@ -120,6 +74,8 @@ func cleanupClusters() {
 			fmt.Printf("Cleaning up leftover cluster: %s\n", cluster)
 			if err := exec.Command("kind", "delete", "cluster", "--name", cluster).Run(); err != nil {
 				fmt.Printf("Warning: failed to delete cluster %s: %v\n", cluster, err)
+			} else {
+				fmt.Printf("Successfully deleted cluster: %s\n", cluster)
 			}
 		}
 	}

--- a/test/e2e/run_e2e_test.go
+++ b/test/e2e/run_e2e_test.go
@@ -20,7 +20,6 @@ func TestCrashLoopBackoffDiagnosis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test cluster: %v", err)
 	}
-	defer cluster.Cleanup()
 
 	// Apply the CrashLoop scenario
 	if err := cluster.ApplyManifest(scenarios.CrashLoopBackoffScenario()); err != nil {
@@ -60,7 +59,6 @@ func TestImagePullBackoffDiagnosis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test cluster: %v", err)
 	}
-	defer cluster.Cleanup()
 
 	// Apply the ImagePullBackoff scenario
 	if err := cluster.ApplyManifest(scenarios.ImagePullBackoffScenario()); err != nil {
@@ -99,7 +97,6 @@ func TestMissingConfigMapDiagnosis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test cluster: %v", err)
 	}
-	defer cluster.Cleanup()
 
 	// Apply the ConfigMap missing scenario
 	if err := cluster.ApplyManifest(scenarios.ConfigMapMissingScenario()); err != nil {
@@ -127,5 +124,109 @@ func TestMissingConfigMapDiagnosis(t *testing.T) {
 
 	if !strings.Contains(strings.ToLower(output), "non-existent-config") {
 		t.Errorf("K8x failed to identify the missing ConfigMap name. Output: %s", output)
+	}
+}
+
+func TestOPAGatekeeperHostPortDeny(t *testing.T) {
+	// Create a unique cluster name
+	clusterName := fmt.Sprintf("k8x-test-%d", time.Now().Unix())
+
+	// Create the test cluster
+	cluster, err := framework.NewClusterFixture(t, clusterName)
+	if err != nil {
+		t.Fatalf("Failed to create test cluster: %v", err)
+	}
+
+	// Step 1: Install Gatekeeper using official Helm chart
+	t.Log("Installing Gatekeeper using Helm...")
+	releaseName := fmt.Sprintf("gatekeeper-%d", time.Now().Unix())
+	if err := cluster.ExecuteCommands(scenarios.GatekeeperInstallationCommands(releaseName)); err != nil {
+		t.Fatalf("Failed to install Gatekeeper: %v", err)
+	}
+
+	// Wait for Gatekeeper to be ready
+	t.Log("Waiting for Gatekeeper deployment to be ready...")
+	if err := cluster.WaitForDeployment("gatekeeper-system", "gatekeeper-controller-manager", 5*time.Minute); err != nil {
+		t.Logf("Warning: Gatekeeper deployment may not be fully ready: %v", err)
+		// Continue anyway - we'll test the policy enforcement
+	}
+
+	// Wait for ConstraintTemplate CRD to be established
+	t.Log("Waiting for ConstraintTemplate CRD to be established...")
+	if err := cluster.WaitForCRD("constrainttemplates.templates.gatekeeper.sh", 2*time.Minute); err != nil {
+		t.Fatalf("ConstraintTemplate CRD not ready: %v", err)
+	}
+
+	// Step 2: Apply the ConstraintTemplate
+	t.Log("Installing HostPort ConstraintTemplate...")
+	if err := cluster.ApplyManifest(scenarios.HostPortConstraintTemplateScenario()); err != nil {
+		t.Fatalf("Failed to apply ConstraintTemplate: %v", err)
+	}
+
+	// Wait for ConstraintTemplate to be established
+	if err := cluster.WaitForConstraintTemplate("k8xhostportforbidden", 2*time.Minute); err != nil {
+		t.Logf("Warning: ConstraintTemplate may not be fully ready: %v", err)
+	}
+
+	// Wait for the constraint CRD to be created by Gatekeeper
+	t.Log("Waiting for K8xHostPortForbidden CRD to be established...")
+	if err := cluster.WaitForCRD("k8xhostportforbidden.constraints.gatekeeper.sh", 5*time.Minute); err != nil {
+		t.Fatalf("K8xHostPortForbidden CRD not ready: %v", err)
+	}
+
+	// Step 3: Apply the Constraint
+	t.Log("Installing HostPort Constraint...")
+	if err := cluster.ApplyManifest(scenarios.HostPortConstraintScenario()); err != nil {
+		t.Fatalf("Failed to apply Constraint: %v", err)
+	}
+
+	// Wait for constraint to be ready
+	if err := cluster.WaitForConstraint("K8xHostPortForbidden", "hostport-not-allowed", 1*time.Minute); err != nil {
+		t.Logf("Warning: Constraint may not be fully ready: %v", err)
+	}
+
+	// Give some time for the admission controller to be ready
+	t.Log("Waiting for admission controller to be ready...")
+	time.Sleep(30 * time.Second)
+
+	// Step 4: Test that rejected deployment fails
+	t.Log("Testing forbidden deployment (with hostPort)...")
+	if err := cluster.ApplyManifest(scenarios.ForbiddenDeploymentScenario()); err == nil {
+		t.Errorf("Forbidden deployment was allowed when it should have been rejected")
+	} else {
+		t.Logf("✓ Forbidden deployment was correctly rejected: %v", err)
+	}
+
+	// Step 5: Run k8x to diagnose why the deployment was rejected
+	t.Log("Running k8x to diagnose the deployment rejection...")
+	output, err := cluster.RunK8x("Why was my most recent deployment rejected? Getting some weird errors.")
+	if err != nil {
+		t.Logf("K8x output: %s", output)
+		t.Fatalf("Failed to run k8x: %v", err)
+	}
+
+	// Step 6: Verify that k8x correctly diagnosed the OPA Gatekeeper policy violation
+	lowerOutput := strings.ToLower(output)
+
+	// Check for OPA/Gatekeeper related terms
+	if !strings.Contains(lowerOutput, "gatekeeper") && !strings.Contains(lowerOutput, "opa") && !strings.Contains(lowerOutput, "policy") {
+		t.Errorf("K8x failed to identify OPA Gatekeeper policy violation. Output: %s", output)
+	}
+
+	// Check for hostPort specific violation
+	if !strings.Contains(lowerOutput, "hostport") {
+		t.Errorf("K8x failed to identify hostPort restriction. Output: %s", output)
+	}
+
+	// Check for constraint/admission controller related terms
+	if !strings.Contains(lowerOutput, "constraint") && !strings.Contains(lowerOutput, "admission") && !strings.Contains(lowerOutput, "forbidden") {
+		t.Errorf("K8x failed to identify admission controller constraint. Output: %s", output)
+	}
+
+	t.Logf("✓ K8x successfully diagnosed the OPA Gatekeeper policy violation")
+
+	// Cleanup Gatekeeper installation
+	if err := cluster.ExecuteCommands(scenarios.GatekeeperUninstallCommands(releaseName)); err != nil {
+		t.Logf("Warning: Failed to cleanup Gatekeeper: %v", err)
 	}
 }


### PR DESCRIPTION
This pull request introduces enhancements to the end-to-end (E2E) testing framework for Kubernetes, focusing on improving debugging capabilities, adding support for Gatekeeper scenarios, and refactoring utilities for better maintainability. Key changes include the addition of a `preserve-on-failure` flag for debugging failed tests, new Gatekeeper-related scenarios, and utility functions for managing clusters and dependencies.
